### PR TITLE
Add support to specify a purchase date in config

### DIFF
--- a/dll/dll/settings.h
+++ b/dll/dll/settings.h
@@ -203,6 +203,9 @@ class Settings {
 private:
     CSteamID steam_id{}; // user id
     CGameID game_id{};
+
+    std::chrono::system_clock::time_point purchase_date{};
+
     std::string name{};
     std::string language{}; // default "english"
     CSteamID lobby_id = k_steamIDNil;
@@ -377,6 +380,9 @@ public:
     const std::string& get_supported_languages() const;
 
     void set_game_id(CGameID game_id);
+
+    std::chrono::system_clock::time_point get_purchase_date();
+    void set_purchase_date(std::chrono::system_clock::time_point purchase_date);
 
     void set_lobby(CSteamID lobby_id);
     CSteamID get_lobby();

--- a/dll/settings.cpp
+++ b/dll/settings.cpp
@@ -141,6 +141,16 @@ const std::string& Settings::get_supported_languages() const
     return this->supported_languages;
 }
 
+std::chrono::system_clock::time_point Settings::get_purchase_date()
+{
+    return purchase_date;
+}
+
+void Settings::set_purchase_date(std::chrono::system_clock::time_point purchase_date)
+{
+    this->purchase_date = purchase_date;
+}
+
 void Settings::set_game_id(CGameID game_id)
 {
     this->game_id = game_id;

--- a/dll/settings_parser.cpp
+++ b/dll/settings_parser.cpp
@@ -724,6 +724,29 @@ static std::set<std::string> parse_supported_languages(class Local_Storage *loca
     return supported_languages;
 }
 
+static void parse_purchase_date(class Settings* settings_client, Settings* settings_server)
+{
+    const char* raw_purchase_date = ini.GetValue("app::general", "purchase_date", "");
+
+    std::chrono::system_clock::time_point purchase_date;
+
+    std::tm time{};
+    std::istringstream is{ raw_purchase_date };
+    is.imbue(std::locale("")); // Default to system locale
+    is >> std::get_time(&time, "%Y/%m/%d %H:%M:%S");
+
+    // if date is formatted incorrectly
+    if (is.fail()) {
+        // default to 4 days ago
+        purchase_date = startup_time - std::chrono::hours(24 * 4);
+    } else {
+        purchase_date = std::chrono::system_clock::from_time_t(std::mktime(&time));
+    }
+
+    settings_client->set_purchase_date(purchase_date);
+    settings_server->set_purchase_date(purchase_date);
+}
+
 // app::dlcs
 static void parse_dlc(class Settings *settings_client, class Settings *settings_server)
 {
@@ -1788,6 +1811,8 @@ uint32 create_localstorage_settings(Settings **settings_client_out, Settings **s
     // supported languages list
     settings_client->set_supported_languages(supported_languages);
     settings_server->set_supported_languages(supported_languages);
+
+    parse_purchase_date(settings_client, settings_server);
 
     parse_simple_features(settings_client, settings_server);
     parse_stats_features(settings_client, settings_server);

--- a/dll/steam_apps.cpp
+++ b/dll/steam_apps.cpp
@@ -140,11 +140,8 @@ uint32 Steam_Apps::GetEarliestPurchaseUnixTime( AppId_t nAppID )
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     if (nAppID == 0) return 0; // steam returns 0
     if (nAppID == UINT32_MAX) return 0; // steam returns 0
-    auto t =
-        // 4 days ago
-        startup_time
-        - std::chrono::hours(24 * 4);
-    auto duration = std::chrono::duration_cast<std::chrono::seconds>(t.time_since_epoch());
+
+    auto duration = std::chrono::duration_cast<std::chrono::seconds>(settings->get_purchase_date().time_since_epoch());
     if (nAppID == settings->get_local_game_id().AppID() || settings->hasDLC(nAppID)) {
         return (uint32)duration.count();
     }

--- a/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
+++ b/post_build/steam_settings.EXAMPLE/configs.app.EXAMPLE.ini
@@ -11,6 +11,11 @@ is_beta_branch=0
 # otherwise will be ignored by the emu and the default 'public' branch will be used
 # default=public
 branch_name=public
+# the date of purchase, some games use this date to provide preorder stuff
+# by default the emu will report a date of purchase that is 4 days ago of game startup
+# Date format: YYYY/mm/dd HH:MM:SS
+# default=
+purchase_date=
 
 [app::dlcs]
 # 1=report all DLCs as unlocked


### PR DESCRIPTION
This PR adds support to specify a purchase date in `configs.app.ini`.

Some games check using `GetEarliestPurchaseUnixTime` when the game was purchased to provide preorder bonus items.
The old logic will be used by default if no `purchase_date` has been specific in `configs.app.ini`.